### PR TITLE
fix: 精简两篇博文的 tags 标签

### DIFF
--- a/src/content/posts/BCP策略和业务影响分析（BIA）.md
+++ b/src/content/posts/BCP策略和业务影响分析（BIA）.md
@@ -3,7 +3,7 @@ title: BCP策略和业务影响分析（BIA）
 published: 2026-08-02
 description: '本文梳理了业务连续性计划（BCP）中的核心——业务影响分析（BIA），重点讲解如何确定业务所能容忍的最大允许中断时间（MTD）。文章系统介绍了MTD、RTO、WRT、RPO、DRP、BRP、SDO等关键概念，并结合实际场景说明各指标如何串联成一个完整的恢复故事，特别解读了服务交付目标（SDO）在降级运行阶段的实际意义。最后介绍了灾难恢复后将运营从备用站点迁回主站点的回切（Failback）流程，并配以完整时间轴图示，帮助读者建立BCP全流程的直观认知。'
 image: 'https://ob-typora.oss-cn-shanghai.aliyuncs.com/images20260802131457485.png'
-tags: [BCP BIA 业务连续性 灾难恢复 CISSP]
+tags: [CISSP]
 category: 企业安全建设
 draft: false 
 lang: 'zh'

--- a/src/content/posts/Vibe Coding 的第一个小程序上线了.md
+++ b/src/content/posts/Vibe Coding 的第一个小程序上线了.md
@@ -3,7 +3,7 @@ title: Vibe Coding 的第一个小程序上线了
 published: 2026-07-31
 description: '本文记录了我作为网络安全工程师，首次通过 Vibe Coding 全程由 AI 开发并上线一款微信小程序「秒题鸭」的经历。这是一款基于腾讯云 CloudBase 打造的多证书备考刷题小程序，首发聚焦 CISSP。文章分享了我做它的初衷、为自己定制的「做题三原则」备考方法论、内置免费 AI 解析的设计思路，以及选择微信 AI 小程序成长计划与腾讯产品生态的原因，并附有小程序功能截图。'
 image: 'https://ob-typora.oss-cn-shanghai.aliyuncs.com/images20260731131755725.png'
-tags: [Vibe Coding 小程序 CloudBase CISSP]
+tags: [Vibe Coding]
 category: 'LLM'
 draft: false
 lang: 'zh'


### PR DESCRIPTION
## 变更内容

精简两篇博文的 frontmatter tags，避免标签过散：

- `BCP策略和业务影响分析（BIA）.md`：`tags: [BCP BIA 业务连续性 灾难恢复 CISSP]` → `tags: [CISSP]`
- `Vibe Coding 的第一个小程序上线了.md`：`tags: [Vibe Coding 小程序 CloudBase CISSP]` → `tags: [Vibe Coding]`

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)